### PR TITLE
Panel lighting electrical

### DIFF
--- a/Models/Panels/Instruments/FlapIndicator/FlapIndicator-systems.xml
+++ b/Models/Panels/Instruments/FlapIndicator/FlapIndicator-systems.xml
@@ -45,5 +45,10 @@ shall keep this attribution information.
       <input>fcs/flap-pos-norm</input>
       <gain>100</gain>
     </pure_gain>
+
+    <!-- Flap index 100 for now, until the instrument to adjust is built-->
+    <switch name="instruments/flap-indicator/flap-index-setting">
+      <default value="100" />
+    </switch>
   </channel>
 </system>

--- a/Models/Panels/Instruments/FlapIndicator/FlapIndicator.xml
+++ b/Models/Panels/Instruments/FlapIndicator/FlapIndicator.xml
@@ -71,7 +71,7 @@
     <format type="string">%3.0f</format>
     <truncate type="bool">false</truncate>
     <character-aspect-ratio type="double">0.8</character-aspect-ratio>
-    <property>fdm/jsbsim/instruments/flap-indicator/flap-pos-percentage</property>    
+    <property>fdm/jsbsim/instruments/flap-indicator/flap-index-setting</property>    
     <alignment>right-top</alignment>
   </text>
 
@@ -79,6 +79,7 @@
     <object-name>FlapIndex</object-name>
     <type>material</type>
     <emission>
+      <factor-prop>fdm/jsbsim/instruments/panel-lighting/ledlight-status</factor-prop>
       <red>0.255</red>
       <green>1.0</green>
       <blue>1.0</blue>

--- a/Models/Panels/Instruments/PanelLighting/PanelLighting-systems.xml
+++ b/Models/Panels/Instruments/PanelLighting/PanelLighting-systems.xml
@@ -14,6 +14,10 @@ shall keep this attribution information.
     <switch name="instruments/panel-lighting/backlight-active">
       <default value="0" />
       <test value="0">
+	<!-- Off backlight if electrical is off -->
+	/systems/electrical/serviceable EQ 0
+      </test>
+      <test value="0">
 	<!-- OFF -->
 	instruments/panel-lighting/backlight-status EQ 0
       </test>
@@ -53,6 +57,10 @@ shall keep this attribution information.
   <channel name="Panel floodlight status">
     <switch name="instruments/panel-lighting/floodlight-active">
       <default value="0" />
+      <test value="0">
+	<!-- Off floodlight if electrical is off -->
+	/systems/electrical/serviceable EQ 0
+      </test>
       <test value="0">
 	<!-- OFF -->
 	instruments/panel-lighting/floodlight-status EQ 0

--- a/Models/Panels/Instruments/PanelLighting/PanelLighting-systems.xml
+++ b/Models/Panels/Instruments/PanelLighting/PanelLighting-systems.xml
@@ -119,6 +119,16 @@ shall keep this attribution information.
     </pure_gain>
   </channel>
 
+  <channel name="Ledlight status">
+    <switch name="instruments/panel-lighting/ledlight-status">
+      <default value="1"/>
+      <test value="0">
+	<!-- Off ledlight if electrical is off -->
+	/systems/electrical/serviceable EQ 0
+      </test>
+    </switch>
+  </channel>
+
   <!-- Needs to be connected with the IRCM instrument on the pedestal -->
   <channel name="IRCM indicators">
     <switch name="instruments/panel-lighting/ircm-auto">


### PR DESCRIPTION
* The backlight, floodlight, and LCDs only turn on if electrical operate
* The Flap index now reflects a controllable index, rather than deflection ratio
